### PR TITLE
Feri/trim zig zag

### DIFF
--- a/hwr/relabeling/pointrobot_relabeling.py
+++ b/hwr/relabeling/pointrobot_relabeling.py
@@ -419,7 +419,18 @@ class PointrobotRelabeler:
         It checks the average orientation difference among the points.
         If it is bigger then a specified threshold, it returns True.
         """
-        return False
+        threshold = math.pi / 2
+        zig_zag = False
+        if len(trajectory) > 1:
+            angle_sum = 0
+            for i, point in enumerate(trajectory[1:]):
+                angle_sum += abs(self._calc_angle(trajectory[i]["action"], point["action"]))
+            
+            angle_diff_average = angle_sum / (len(trajectory) - 1)
+            if angle_diff_average > threshold:
+                zig_zag = True
+
+        return zig_zag
 
 
     def _calc_angle(self, action1, action2):

--- a/hwr/relabeling/pointrobot_relabeling.py
+++ b/hwr/relabeling/pointrobot_relabeling.py
@@ -37,17 +37,21 @@ class PointrobotRelabeler:
 
     def relabel(self, trajectory, env):
         """creates a new workspace and goal for the given trajectory."""
-
+        
+        relabeled_trajectory = []
         # rescale the trajectory if normalization is used in the environment:
         if env.normalize:
             trajectory = self._rescale_trajectory(trajectory, env)
 
         if self._mode == 'erease':
-            relabeled_trajectory = self._erease_relabel(trajectory, env)
+            if not self._zig_zag_path(trajectory):
+                relabeled_trajectory = self._erease_relabel(trajectory, env)
         elif self._mode == 'random':
-            relabeled_trajectory = self._random_relabel(trajectory, env)
+            if not self._zig_zag_path(trajectory):
+                relabeled_trajectory = self._random_relabel(trajectory, env)
         elif self._mode == 'slding':
-            relabeled_trajectory = self._sliding_relabel(trajectory, env)
+            if not self._zig_zag_path(trajectory):
+                relabeled_trajectory = self._sliding_relabel(trajectory, env)
         elif self._mode == 'straight_line':
             relabeled_trajectory = self. _straight_line_relabel(trajectory, env)
 
@@ -408,6 +412,24 @@ class PointrobotRelabeler:
             trajectory = []
 
         return trajectory
+
+
+    def _zig_zag_path(self, trajectory):
+        """returns True, if the trajectory contains some serious zig zaging.
+        It checks the average orientation difference among the points.
+        If it is bigger then a specified threshold, it returns True.
+        """
+        return False
+
+
+    def _calc_angle(self, action1, action2):
+        """calculates the angle between two successive actions."""
+        length1 = np.linalg.norm(action1)
+        length2 = np.linalg.norm(action2)
+        cos_theta = action1 @ action2 / (length1 * length2)
+        cross = action1[0] * action2[1] - action1[1] * action2[0]
+        sin_theta = cross / (length1 * length2)
+        return math.atan2(sin_theta, cos_theta)
 
 
     def _rescale_trajectory(self, trajectory, env):

--- a/tests/test_pointrobot_relabeler.py
+++ b/tests/test_pointrobot_relabeler.py
@@ -216,20 +216,20 @@ class PointrobotRelabelerTests(unittest.TestCase):
 
         trajectory = []
         trajectory.append({'workspace': workspace, 'position': np.array([21.0, 5.0]),
-            'done': False, 'reward': env.step_reward})
+            'done': False, 'reward': env.step_reward, 'action': np.ones((2,))})
         trajectory.append({'workspace': workspace, 'position': np.array([21.3, 4.7]),
-            'done': False, 'reward': env.step_reward})
+            'done': False, 'reward': env.step_reward, 'action': np.ones((2,))})
         trajectory.append({'workspace': workspace, 'position': np.array([21.6, 4.4]),
-            'done': True, 'reward': env.collision_reward})
+            'done': True, 'reward': env.collision_reward, 'action': np.ones((2,))})
 
         # etalon solutions:
         etalon_relabeled_traj = []
         etalon_relabeled_traj.append({'workspace': etalon_workspace, 'position': np.array([21.0, 5.0]),
-            'done': False, 'reward': env.step_reward})
+            'done': False, 'reward': env.step_reward, 'action': np.ones((2,))})
         etalon_relabeled_traj.append({'workspace': etalon_workspace, 'position': np.array([21.3, 4.7]),
-            'done': False, 'reward': env.step_reward})
+            'done': False, 'reward': env.step_reward, 'action': np.ones((2,))})
         etalon_relabeled_traj.append({'workspace': etalon_workspace, 'position': np.array([21.6, 4.4]), 
-            'done': True, 'reward': env.goal_reward})
+            'done': True, 'reward': env.goal_reward, 'action': np.ones((2,))})
 
         relabeled_traj = relabeler.relabel(trajectory, env)
 
@@ -287,11 +287,10 @@ class PointrobotRelabelerTests(unittest.TestCase):
         angles = np.random.uniform(low=0., high=2 * math.pi, size=(num_angles,))
         actions = [np.array([math.cos(angle), math.sin(angle)]) for angle in angles]
 
-        env = test_env(radius=0.5)
         relabeler = PointrobotRelabeler(ws_shape=(32, 32),
                                         mode='erease')
         
-        for test in range(num_tests):
+        for _ in range(num_tests):
             i1 = np.random.randint(low=0, high=num_angles)
             i2 = np.random.randint(low=0, high=num_angles)
             action1, angle1 = actions[i1], angles[i1]
@@ -304,7 +303,37 @@ class PointrobotRelabelerTests(unittest.TestCase):
             d_theta = relabeler._calc_angle(action1, action2)
 
             self.assertAlmostEqual(abs(d_theta), d_theta_ground)
-    
+
+
+    def test_zig_zag(self):
+        """tests the zig-zag finder method of the relabeler."""
+
+        relabeler = PointrobotRelabeler(ws_shape=(32, 32),
+                                        mode='erease')
+
+        trajectories = []
+        trajectory = []
+        for i in range(10):
+            angle = math.pow(-1, i) * math.pi / 3
+            action = np.array([math.cos(angle), math.sin(angle)])
+            trajectory.append({"action": action})
+        trajectories.append(trajectory)
+
+        trajectory = []
+        for _ in range(10):
+            angle = np.random.uniform(low=0, high=math.pi / 2)
+            action = np.array([math.cos(angle), math.sin(angle)])
+            trajectory.append({"action": action})
+        trajectories.append(trajectory)
+
+        trajectory = []
+        trajectory.append({"action": np.array([0, 1])})
+        trajectories.append(trajectory)
+
+        results = [True, False, False]
+
+        for i, trajectory in enumerate(trajectories):
+            self.assertEqual(results[i], relabeler._zig_zag_path(trajectory))    
 
 
 if __name__ == '__main__':

--- a/tests/test_pointrobot_relabeler.py
+++ b/tests/test_pointrobot_relabeler.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import math
 
 from hwr.relabeling.pointrobot_relabeling import PointrobotRelabeler
 from math import isclose
@@ -278,6 +279,32 @@ class PointrobotRelabelerTests(unittest.TestCase):
         for point in relabeled_traj:
             self.assertAlmostEqual(normal_vect @ point["position"], c)
             
+
+    def test_calc_angle(self):
+        """tests the angle calculation method of the relabeler."""
+        num_angles = 10
+        num_tests = 100
+        angles = np.random.uniform(low=0., high=2 * math.pi, size=(num_angles,))
+        actions = [np.array([math.cos(angle), math.sin(angle)]) for angle in angles]
+
+        env = test_env(radius=0.5)
+        relabeler = PointrobotRelabeler(ws_shape=(32, 32),
+                                        mode='erease')
+        
+        for test in range(num_tests):
+            i1 = np.random.randint(low=0, high=num_angles)
+            i2 = np.random.randint(low=0, high=num_angles)
+            action1, angle1 = actions[i1], angles[i1]
+            action2, angle2 = actions[i2], angles[i2]
+
+            d_theta_ground = abs(angle1 - angle2)
+            if d_theta_ground > math.pi:
+                d_theta_ground = 2 * math.pi - d_theta_ground
+            
+            d_theta = relabeler._calc_angle(action1, action2)
+
+            self.assertAlmostEqual(abs(d_theta), d_theta_ground)
+    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Trajectories which have a very high zig-zagging are thrown away during relabeling. They are not going to be relabeled as good examples.